### PR TITLE
use eu.gcr.io instead of registry.gitlab.com (pull fails)

### DIFF
--- a/manifests/backend/deployment-cm.yaml
+++ b/manifests/backend/deployment-cm.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-limits.yaml
+++ b/manifests/backend/deployment-limits.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-liveness-probe.yaml
+++ b/manifests/backend/deployment-liveness-probe.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-metadata.yaml
+++ b/manifests/backend/deployment-metadata.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-pvc.yaml
+++ b/manifests/backend/deployment-pvc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         imagePullPolicy: Always
         volumeMounts:
         - name: fortune

--- a/manifests/backend/deployment-readiness-probe-envs.yaml
+++ b/manifests/backend/deployment-readiness-probe-envs.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-readiness-probe.yaml
+++ b/manifests/backend/deployment-readiness-probe.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-redis-state.yaml
+++ b/manifests/backend/deployment-redis-state.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-secret.yaml
+++ b/manifests/backend/deployment-secret.yaml
@@ -21,7 +21,7 @@ spec:
           secretName: mysecret        
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/backend/deployment-volume.yaml
+++ b/manifests/backend/deployment-volume.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         imagePullPolicy: Always
         volumeMounts:
         - name: fortune

--- a/manifests/backend/deployment.yaml
+++ b/manifests/backend/deployment.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: timber-backend
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080

--- a/manifests/debugging/deployment-nonexisting-image.yaml
+++ b/manifests/debugging/deployment-nonexisting-image.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: timber-debugging
-        image: registry.gitlab.com/containersolutions/timber:non-existing-image
+        image: eu.gcr.io/container-solutions-workshops/timber:non-existing-image
         ports:
         - containerPort: 8080

--- a/manifests/debugging/deployment-probes-broken.yaml
+++ b/manifests/debugging/deployment-probes-broken.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-debugging
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         env:

--- a/manifests/debugging/deployment-resources.yaml
+++ b/manifests/debugging/deployment-resources.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-debugging
-        image: registry.gitlab.com/containersolutions/timber/backend
+        image: eu.gcr.io/container-solutions-workshops/timber/backend
         ports:
         - containerPort: 8080
         resources:

--- a/manifests/frontend/deployment.yaml
+++ b/manifests/frontend/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: timber-frontend
-        image: registry.gitlab.com/containersolutions/timber/frontend
+        image: eu.gcr.io/container-solutions-workshops/timber/frontend
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
while testing before the conference, deployments were failing with ImagePullBackoff.
testing manually by `docker pull` seems really slow. I'm not sure if its:
- a network issue between google and gitlab infra
- gitlab internal issue

Anyway this is a quick fix ...